### PR TITLE
Add support for Sentry breadcrumbs.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 *.suo
 *.user
 *.sln.docstates
+/.vs/
 
 # Build results
 [Dd]ebug/
@@ -17,6 +18,7 @@ build/
 bld/
 [Bb]in/
 [Oo]bj/
+/packages/
 
 # Roslyn cache directories
 *.ide/

--- a/NLog.Targets.Sentry/NLog.Targets.Sentry.csproj
+++ b/NLog.Targets.Sentry/NLog.Targets.Sentry.csproj
@@ -55,9 +55,7 @@
     <None Include="NLog.Targets.Sentry.nuspec">
       <SubType>Designer</SubType>
     </None>
-    <None Include="Packages.config">
-      <SubType>Designer</SubType>
-    </None>
+    <None Include="packages.config" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Import Project="..\packages\Robusto.1.0.2\build\Robusto.targets" Condition="Exists('..\packages\Robusto.1.0.2\build\Robusto.targets')" />

--- a/NLog.Targets.Sentry/NLog.Targets.Sentry.nuspec
+++ b/NLog.Targets.Sentry/NLog.Targets.Sentry.nuspec
@@ -12,7 +12,9 @@
     <description>$description$</description>
     <copyright>$copyright$</copyright>
     <tags>NLog Sentry Log Logging</tags>
-    <releaseNotes>Changed to take in the environment and timeout parameters from the target attribute in the NLog config instead of the appSettings
+    <releaseNotes>
+      Added Sentry breadcrumb support by adding a minimum log level ("MinLogLevelForEvent") required for Sentry event generation.
+      NLog Events with lower log levels will be recorded as breadcrumbs.
     </releaseNotes>
   </metadata>
 </package>


### PR DESCRIPTION
Breadcrumbs are activated by setting the `minLogLevelForEvent` property. Events with lower than this minimum level will be added to the breadcrumb trail.